### PR TITLE
Add maven shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>2.0</version>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>shade</goal>
+                  </goals>
+                  <configuration>
+                    <finalName>${project.name}</finalName>
+                    <transformers>
+                      <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        <mainClass>org.openjdk.jmh.Main</mainClass>
+                      </transformer>
+                    </transformers>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
             <!--
             <plugin>
                 <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
This adds the shade plugin to pom.xml to generate a runnable JAR with the JMH benchmarks. After building, the benchmarks JAR should be in `jvector-tests/target/jvector-tests-*-test-jar-with-dependencies.jar`

To get all the JMH options to control how the benchmark runs:
```
java -jar jvector-tests/target/jvector-tests-*-test-jar-with-dependencies.jar -h
```

To list all benchmarks (including parameters):
```
java -jar jvector-tests/target/jvector-tests-*-test-jar-with-dependencies.jar -lp
```

To run a single benchmark with custom config (warmup, iterations, specific JVM, etc.):
```
java -jar jvector-tests/target/jvector-tests-*-test-jar-with-dependencies.jar \
  "^io.github.jbellis.jvector.microbench.GraphBuildBench.testGraphBuild$" \
  -wi 30 -w 2 \
  -i 10 -r 6 \
  -t 1 -f 1 -foe false \
  -jvm ${MY_OTHER_JAVA_HOME}/bin/java \
  -jvmArgs "-Xmx16g"
```